### PR TITLE
Definition of robot's orientation

### DIFF
--- a/robotic-equipment.tex
+++ b/robotic-equipment.tex
@@ -59,7 +59,7 @@ No two robots are allowed to use the same color assignment.
 The centre dot color determines the team and is either blue or yellow.
 All markers must be cut from stock specified by the SSL-Vision
 documentation. While teams may acquire the standard color paper in advance of
-the competition, limited quantities of standardized colored paper or cardstock for 
+the competition, limited quantities of standardized colored paper or cardstock for
 all required colors will be provided at the competition.
 The set of legal color assignments is shown in \autoref{fig:stdcolors}.
 Note that the organisers reserve the right to change these color assignments at
@@ -73,6 +73,12 @@ any time, if required.
 \end{figure}
 
 Teams are encouraged to select color assignments with IDs 0--7 because they have been experimentally found more stable, as there is no risk that the back two dots ``color-bleed'' into each other.
+
+Any device which allows the robot to transfer momentum to the ball, which is not
+momentum caused by the robot's movement, is only allowed if it touches the ball
+at the front side of the robot. The front side is parallel to the line between
+the upper two markers as depicted in \autoref{fig:stdpattern}.
+
 
 \subsection{Autonomy}
 The robotic equipment is to be fully autonomous.


### PR DESCRIPTION
Currently, the rules do not define that kicks made by a robot
should align with the robot's orientation. A team might oppose to this convention
and gain advantage by drastically reducing the opponent's ability to predict kicks.
It is ok to make prediction of the shot direction difficult, as long as the kick
happens at the robot's front side.