### PR TITLE
Autonomous Ball Placement, more concise AutoRef

### DIFF
--- a/ball-in-and-out-of-play.tex
+++ b/ball-in-and-out-of-play.tex
@@ -8,6 +8,25 @@ The ball is out of play when:
 \end{itemize}
 
 When the ball goes out of play, robots should remain 500\,mm from the ball as the ball is placed until the restart signal is given by the referee.
+The referee or the assistant referee will either manually
+place the ball or indicate the position of ball placement to one of the teams.
+If a team is assigned with a ball placement task, the play is considered as stopped
+with the exception that the placing team is allowed to approach and touch the ball.
+A ball is considered placed successfully if
+\begin{itemize}
+\item no more than 15 seconds passed since the placement command
+\item there is no robot within 500\,mm distance to the ball
+\item the ball is stationary
+\item the ball is at a position within 100\,mm radius from the requested position
+\end{itemize}
+
+If a team repeatedly fails to place the ball, the referee may stop assigning
+ball placement tasks to this team.
+
+If, during the ball placement, a robot of the non-placing team is touching the ball,
+an indirect free kick is awarded, to be taken from the placement location.
+If the ball was travelling with more than 1.5\,m/s at the time of contact, the indirect
+free kick is awarded to non-placing team. Otherwise, it is awarded to the ball placing team.
 
 \subsection{Ball In Play}
 The ball is in play at all other times.

--- a/referee.tex
+++ b/referee.tex
@@ -91,11 +91,8 @@ The referee should use a black stick or some other device when repositioning the
 
 \item
 The referee may be assisted by an autonomous referee application provided by
-one or both of the competing teams, if both teams agree. The referee may
-also be assisted by an autonomous or semi-autonomous application provided
-by the league organizers or by a team not participating in the current
-match, at the referee's own discretion, provided that the application is
-operated or monitored by a neutral party.
+the league organizers, at the referee's own discretion, provided that the
+application is operated or monitored by a neutral party.
 
 \item
 The outer region of the field surface which is further than 300\,mm away from


### PR DESCRIPTION
The league encourages all referees to use an autonomous refereeing application  (AutoRef) as assistance.
All 3 participating solutions from 2016's Technical Challenge may be used for
this purpose.
An AutoRef enables autonomous ball placement.