### PR TITLE
Don't restrict the penalty keeper's orientation

### DIFF
--- a/penalty-kick.tex
+++ b/penalty-kick.tex
@@ -22,7 +22,7 @@ The robot taking the penalty kick:
 The defending goalkeeper:
 
 \begin{itemize}
-\item remains between the goalposts, touches its goal line, and faces outward of the goal, until the ball has been kicked; it is allowed to move before the ball has been kicked, as long as its motion does not break any of these constraints
+\item remains between the goalposts and touches its goal line until the ball has been kicked; it is allowed to move before the ball has been kicked, as long as its motion does not break any of these constraints
 \end{itemize}
 
 The robots other than the kicker are located:


### PR DESCRIPTION
At RoboCup 2016 in Leipzig, there was a discussion about the penalty keeper's orientation. The rules state that the keeper must face outwards, but there seems to be no reason to restrict the keepers orientation.
This only limits the creativity of teams for the implementation of their penalty keeper.
I suggest to remove this restriction.