### PR TITLE
clarification of pushing rule

### DIFF
--- a/fouls-and-misconduct.tex
+++ b/fouls-and-misconduct.tex
@@ -35,6 +35,8 @@ dribbling started
   without entering the opponent's goal
 \item touches the ball while in play, while being located partially or
 entirely within its opponent's defense area
+\item touches the ball such that the ball touches an opponent robot and travels along with the opponent robot in direction of the
+opponent robot for more than 200 mm or until the opponent enters its defense area, while both robots keep contact to the ball.
 \item commits any other offence, not previously mentioned in \autoref{sec:fouls-and-misconduct}, for which play is stopped to caution or dismiss a robot
 \end{itemize}
 
@@ -53,7 +55,7 @@ A team is cautioned and shown the yellow card if a robot on that team commits an
 \item \added{repeatedly} travels faster than 1.5\,m/s while the ball is
 out of play, no restart of play has been called, and the game is in neither a
 time-out, half-time, nor similar break in gameplay such as the interval before
-extra time or a penalty shootout 
+extra time or a penalty shootout
 \end{enumerate}
 
 Upon receipt of a yellow card, the number of robots allowed on the field for the penalised team decreases by one.


### PR DESCRIPTION
This rule clarification makes it easier to penalize pushing robots, especially as an Autoref