### PR TITLE
Change the maximum ball speed to 6.5m/s

### DIFF
--- a/fouls-and-misconduct.tex
+++ b/fouls-and-misconduct.tex
@@ -28,7 +28,7 @@ An indirect free kick is also awarded to the opposing team if a robot:
 \item dribbles the ball over 1000 mm, measured linearly from the ball location where the
 dribbling started
 \item touches the ball such that the top of the ball travels more than 150\,mm from the ground, and the ball subsequently enters their opponent's goal, without having either touched a teammate (while below 150\,mm) or remained in contact with the ground (stopped bouncing).
-\item kicks the ball such that it exceeds \removed{8} \added{6.5}\,m/s in speed
+\item kicks the ball such that it exceeds \removed{8} \added{6.5}\,m/s in \added{absolute} speed \added{(in 3d-space)}
 \item tips over, breaks or drops parts on the field in a way that gives its team unfair advantage
 \item touches the ball such that the ball, without touching any other
   robot, subsequently crosses the  midline and then the opponent's goal line

--- a/fouls-and-misconduct.tex
+++ b/fouls-and-misconduct.tex
@@ -28,7 +28,7 @@ An indirect free kick is also awarded to the opposing team if a robot:
 \item dribbles the ball over 1000 mm, measured linearly from the ball location where the
 dribbling started
 \item touches the ball such that the top of the ball travels more than 150\,mm from the ground, and the ball subsequently enters their opponent's goal, without having either touched a teammate (while below 150\,mm) or remained in contact with the ground (stopped bouncing).
-\item kicks the ball such that it exceeds 8\,m/s in speed
+\item kicks the ball such that it exceeds \removed{8} \added{6.5}\,m/s in speed
 \item tips over, breaks or drops parts on the field in a way that gives its team unfair advantage
 \item touches the ball such that the ball, without touching any other
   robot, subsequently crosses the  midline and then the opponent's goal line


### PR DESCRIPTION
This change applies to both divisions. Even though the field increases quite a bit for division A, the maximum allowed ball speed will be reduced from 8m/s to 6.5m/s.

Currently, it is very common to score goals from large distance, even against strong teams. The reason is that the ball is fast enough to make it through a hole in the defense without the defenders being able to react in time. This is not a bad thing by itself, the defense should just anticipate passes and future attack maneuvers. However, the offense is currently very one-dimensional. It all boils down to finding or forcing a hole in the defense and exploiting it. There is only little advantage gained by being able to bring the ball towards the opponent goal without losing possession or getting marked. By reducing the maximum ball speed, long distance shots are less likely to succeed resulting in a stronger focus on positional play.

The signature high pace of our league will not be affected by this change. First, the viewer will most likely not even notice the difference in shoot speed and second, the high pace is not affected by the speed of the robots or the speed of the ball, but of the frequency of actions (e.g. passes, goal shots).