### PR TITLE
Divisions

### DIFF
--- a/competition-rules.tex
+++ b/competition-rules.tex
@@ -101,3 +101,6 @@ If two or more teams are equal on the basis of the above criteria, the tiebreaki
 \item greater number of goals scored in all group matches between the teams concerned
 \item drawing of lots by the Organising Committee
 \end{itemize}
+
+\subsection{Divisions}\label{sec:divisions}
+The Small Size League is divided into two divisions with separate tournaments: Division A and division B. Division A is aimed at advanced teams whereas new and/or less competitive teams can play in division B. Each team will only play in one of those two divisions. When submitting the qualification material, the team also chooses a preferred division including a short rationale. The OC will have the final word.


### PR DESCRIPTION
Starting in 2018, the Small Size League will be divided into two divisions with separate tournaments: Division A and division B. Division A is aimed at advanced teams whereas new and/or less competitive teams can play in division B. Each team will only play in one of those two divisions. When submitting the qualification material, the team also chooses a preferred division including a short rationale. The OC will have the final word. We are aiming at around 12 teams per division.

There are multiple benefits of having two divisions.

The SSL has a rather high entry barrier. Our goal is to further advance the league while keeping the entry barrier at a reasonable level. With splitting the league, we can challenge seasoned teams while still being attractive for newcomers. The qualification criteria for the division B can even be lowered a bit without hurting the competition.

Feedback from this year’s RoboCup has shown that it is very important for teams to face off against opponents of similar skill. Dividing the league into two divisions rids a lot of the one sided games in exchange for more interesting match-ups.