### PR TITLE
Remove the free ticket for rule violations

### DIFF
--- a/ball-in-and-out-of-play.tex
+++ b/ball-in-and-out-of-play.tex
@@ -21,7 +21,8 @@ The automatic referee will indicate the position of ball placement to the team t
 \item The ball must be visible and must not be inside a field or goal corner or behind the goal, before the ball placement starts.
 \item The human referee can decide to place the ball manually at any time.
 \item The human referee can decide to disable automatic ball placement for the rest of the game. TC/OC must agree with this decision.
-\item When a team has failed to place the ball five times in a row, it is not allowed to place the ball for the rest of the game half. All freekicks are awarded to the opposing team. If the team is awarded a penalty kick, or both teams fail to place the ball repeatedly, the ball is placed by the human referee.
+\item When a team has failed to place the ball five times in a row, it is not allowed to place the ball for the rest of the game half.
+All freekicks that were a result of the ball leaving the field, are awarded to the opposing team. For all other rule violations or when both teams failed to place the ball, the ball is placed by the human referee.
 \item If no team can place the ball, the ball is placed by the human referee.
 \end{itemize}
 }


### PR DESCRIPTION
When a team has failed to place the ball five times in a row, all
free kicks were awarded to the opposing team. This team had a free
ticket for rule violations, as it always got a free kick for it.
Now, it is only awarded a free kick if the ball left the field